### PR TITLE
Depreciated method

### DIFF
--- a/Unit_3_Data_Acquisition/3_1_Screen_scrapers_and_spiders_Selenium.py
+++ b/Unit_3_Data_Acquisition/3_1_Screen_scrapers_and_spiders_Selenium.py
@@ -6,6 +6,7 @@
 
 # %% load packages
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 
 # %% specifiy a webdriver
 browser = webdriver.Firefox()
@@ -21,7 +22,7 @@ browser.execute_script("window.scrollTo(0, 2000)")
 
 # %% locate the next button
 next_button = browser.\
-    find_element_by_partial_link_text('Next')
+    find_element(by=By.PARTIAL_LINK_TEXT,value='Next')
 
 # %% click the next button
 next_button.click()


### PR DESCRIPTION
Dear professors,

As I tried to replicate selenium web scraping for my project, I found that the method used to `find_element_by_partial_link_text` was depreciated, according to [Selenium](https://github.com/SeleniumHQ/selenium/blob/a4995e2c096239b42c373f26498a6c9bb4f2b3e7/py/CHANGES).
![Screenshot2022-09-30 at 22 08 59@2x](https://user-images.githubusercontent.com/89454174/193378985-943ec9c5-c2ce-4e0d-91e2-556f6e1dd52d.png)
